### PR TITLE
Fix typo in README re: config

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ is built (see below).
 value when the image is run.
 * No default value for this variable is provided in any `.env` file.
 
-`REACT_APP_WX_FILES_SERVICE_URL`
+`REACT_APP_WXFS_URL`
 * URL of Wx Files metadata/data service.
 
 `NODE_ENV`


### PR DESCRIPTION
Should be self explanatory. The [documentation](https://github.com/pacificclimate/wx-files-frontend/blob/master/README.md#environment-variables) doesn't match the [usage in the code](https://github.com/pacificclimate/wx-files-frontend/blob/master/src/data-services/wx-files-data-service.js#L31).